### PR TITLE
Update exercises.ipynb

### DIFF
--- a/exercises.ipynb
+++ b/exercises.ipynb
@@ -298,7 +298,7 @@
     "# Should return $9.00\n",
     "\n",
     "# calculate_ticket_price(70, \"Sunday\", False)\n",
-    "# Should return $15.00"
+    "# Should return $12.00"
    ]
   }
  ],


### PR DESCRIPTION
Corrected exercise 10, the second result says should be $15 but it comes out to 12. Explanation: base = $10, day == 'Sunday' (base += 5 == $15), is_student == false, no discount applied, person is 70, if age > 65: discount = price * .10 (15 * .2 = 3) 15 - 3 = 12, should return $12